### PR TITLE
fix: removed redundant scroll button to avoid duplicated rendering

### DIFF
--- a/apps/www/content/2.components/conversation.md
+++ b/apps/www/content/2.components/conversation.md
@@ -160,7 +160,6 @@ import {
       <MessageContent>Hi there!</MessageContent>
     </Message>
   </ConversationContent>
-  <ConversationScrollButton />
 </Conversation>
 ```
 


### PR DESCRIPTION
## Description

This update refines the usage example of the <Conversation /> component by removing a redundant `<ConversationScrollButton />` [[link](https://www.ai-elements-vue.com/components/conversation#install-manually)].

Since `<ConversationScrollButton />` is already included within `<Conversation />`, the previous example could cause developers to render it twice unintentionally. This branch could prevent this case by updating the example.