### PR TITLE
fix(cli): pin shadcn-vue version to fix wrong install directory

### DIFF
--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -29,7 +29,7 @@ if (args.length >= 2 && args[0] === 'add') {
   const component = args[1]
   const targetUrl = new URL(`/${component}.json`, 'https://registry.ai-elements-vue.com').toString()
 
-  const fullCommand = `${commandPrefix} shadcn-vue@latest add ${targetUrl}`
+  const fullCommand = `${commandPrefix} shadcn-vue@2.3.3 add ${targetUrl}`
   const result = spawnSync(fullCommand, {
     stdio: 'inherit',
     shell: true,
@@ -56,7 +56,7 @@ else {
         new URL(`/${item.name}.json`, 'https://registry.ai-elements-vue.com').toString(),
       )
 
-      const fullCommand = `${commandPrefix} shadcn-vue@latest add ${componentUrls.join(' ')}`
+      const fullCommand = `${commandPrefix} shadcn-vue@2.3.3 add ${componentUrls.join(' ')}`
       const result = spawnSync(fullCommand, {
         stdio: 'inherit',
         shell: true,


### PR DESCRIPTION
This is a workaround for an upstream bug in shadcn-vue 2.4.0. The `resolveNestedFilePath` function was modified in commit [ae7f01c](https://github.com/unovue/shadcn-vue/commit/ae7f01c56ad14de4f97c3f4393c8d6da16b9c24c) to fix `aliases.ui` inconsistent behavior, but this change breaks path resolution for components with additional path levels like `components/ai-elements/...`, causing components to be installed to the wrong directory.

This PR pins shadcn-vue to version 2.3.3 to work around the issue until it's fixed upstream.

Closed #67 