### PR TITLE
chore: add root .npmrc for consistent workspace dependency hoisting

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+shamefully-hoist=true
+strict-peer-dependencies=false


### PR DESCRIPTION
## Problem Description
When running `pnpm install` from the root directory, the dependency hoisting strategy may be inconsistent with subdirectory configurations, causing module resolution issues (e.g., dayjs import errors).
fixed: #70 

<img width="1901" height="1368" alt="4bd86d69833768955160db807d56703b" src="https://github.com/user-attachments/assets/357b2b5c-c5e7-4a57-87b3-b70a37db293b" />


## Solution
Add `.npmrc` file at the root level to unify pnpm configuration across the entire workspace:
- `shamefully-hoist=true`: Ensures dependencies are hoisted to the `node_modules` root directory, compatible with Nuxt/Vite module resolution mechanism
- `strict-peer-dependencies=false`: Allows flexible peer dependency resolution to avoid installation failures

## Impact
- ✅ Ensures `pnpm install` works correctly when executed from the root directory
- ✅ Unifies dependency hoisting strategy across the entire workspace
- ✅ Maintains consistency with existing `apps/www/.npmrc` configuration
