### PR TITLE
fix: resolve potential attribute duplication and simplify slot handli…

### DIFF
--- a/packages/elements/src/message/MessageAttachments.vue
+++ b/packages/elements/src/message/MessageAttachments.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
-import { cn } from '@repo/shadcn-vue/lib/utils'
 import { useSlots } from 'vue'
+import { cn } from '@repo/shadcn-vue/lib/utils'
+
+defineOptions({
+  inheritAttrs: false,
+})
 
 interface Props {
   class?: HTMLAttributes['class']
@@ -15,12 +19,7 @@ const slots = useSlots()
 <template>
   <div
     v-if="slots.default"
-    :class="
-      cn(
-        'ml-auto flex w-fit flex-wrap items-start gap-2',
-        props.class,
-      )
-    "
+    :class="cn('ml-auto flex w-fit flex-wrap items-start gap-2', props.class)"
     v-bind="$attrs"
   >
     <slot />


### PR DESCRIPTION
Add `inheritAttrs: false` to prevent Vue from automatically attaching non-prop
attributes to the root element, avoiding duplicated bindings when using `$attrs`.