### PR TITLE
chore: remove unnecessary type assertion on `props.class`

### DIFF
--- a/apps/www/content/3.components/1.chatbot/chain-of-thought.md
+++ b/apps/www/content/3.components/1.chatbot/chain-of-thought.md
@@ -152,7 +152,7 @@ const statusStyles = {
         'flex gap-2 text-sm',
         statusStyles[props.status],
         'fade-in-0 slide-in-from-top-2 animate-in',
-        props.class as string,
+        props.class,
       )
     "
     v-bind="$attrs"

--- a/apps/www/content/3.components/1.chatbot/message.md
+++ b/apps/www/content/3.components/1.chatbot/message.md
@@ -50,7 +50,7 @@ const props = defineProps<Props>()
       cn(
         'group flex w-full max-w-[80%] gap-2',
         props.from === 'user' ? 'is-user ml-auto justify-end' : 'is-assistant',
-        props.class as string,
+        props.class,
       )
     "
     v-bind="$attrs"
@@ -575,7 +575,7 @@ const props = defineProps<Props>()
     :class="
       cn(
         'mt-4 flex w-full items-center justify-between gap-4',
-        props.class as string,
+        props.class,
       )
     "
     v-bind="$attrs"

--- a/packages/elements/src/chain-of-thought/ChainOfThoughtHeader.vue
+++ b/packages/elements/src/chain-of-thought/ChainOfThoughtHeader.vue
@@ -21,7 +21,7 @@ const { isOpen, setIsOpen } = useChainOfThought()
       :class="
         cn(
           'flex w-full items-center gap-2 text-muted-foreground text-sm transition-colors hover:text-foreground',
-          props.class as string,
+          props.class,
         )
       "
       v-bind="$attrs"

--- a/packages/elements/src/chain-of-thought/ChainOfThoughtStep.vue
+++ b/packages/elements/src/chain-of-thought/ChainOfThoughtStep.vue
@@ -29,7 +29,7 @@ const statusStyles = {
         'flex gap-2 text-sm',
         statusStyles[props.status],
         'fade-in-0 slide-in-from-top-2 animate-in',
-        props.class as string,
+        props.class,
       )
     "
     v-bind="$attrs"

--- a/packages/elements/src/message/MessageToolbar.vue
+++ b/packages/elements/src/message/MessageToolbar.vue
@@ -14,7 +14,7 @@ const props = defineProps<Props>()
     :class="
       cn(
         'mt-4 flex w-full items-center justify-between gap-4',
-        props.class as string,
+        props.class,
       )
     "
     v-bind="$attrs"


### PR DESCRIPTION
Removed the type definition of class in the template as string