### PR TITLE
chore(docs): replace non-existent Input component with PromptInput in examples

### DIFF
--- a/apps/www/content/3.components/1.chatbot/sources.md
+++ b/apps/www/content/3.components/1.chatbot/sources.md
@@ -158,7 +158,7 @@ import {
 } from '@/components/ai-elements/conversation'
 import { Message, MessageContent } from '@/components/ai-elements/message'
 import {
-  Input,
+  PromptInput,
   PromptInputSubmit,
   PromptInputTextarea,
 } from '@/components/ai-elements/prompt-input'
@@ -231,7 +231,7 @@ function getTextParts(message: any) {
         </Conversation>
       </div>
 
-      <Input
+      <PromptInput
         class="mt-4 w-full max-w-2xl mx-auto relative"
         @submit.prevent="handleSubmit"
       >
@@ -245,7 +245,7 @@ function getTextParts(message: any) {
           :disabled="!input.trim()"
           class="absolute bottom-1 right-1"
         />
-      </Input>
+      </PromptInput>
     </div>
   </div>
 </template>

--- a/apps/www/content/3.components/1.chatbot/suggestion.md
+++ b/apps/www/content/3.components/1.chatbot/suggestion.md
@@ -116,7 +116,13 @@ import {
   ConversationScrollButton,
 } from '@/components/ai-elements/conversation'
 import { Message, MessageContent } from '@/components/ai-elements/message'
+import {
+  PromptInput,
+  PromptInputSubmit,
+  PromptInputTextarea,
+} from '@/components/ai-elements/prompt-input'
 import { Response } from '@/components/ai-elements/response'
+import { Suggestion, Suggestions } from '@/components/ai-elements/suggestion'
 
 const input = ref('')
 const { sendMessage, status } = useChat()
@@ -124,7 +130,7 @@ const { sendMessage, status } = useChat()
 function handleSubmit() {
   if (input.value.trim()) {
     sendMessage({ text: input.value })
-    setInput('')
+    input.value = ''
   }
 }
 
@@ -146,7 +152,7 @@ function handleSuggestionClick(suggestion: string) {
           />
         </Suggestions>
 
-        <Input class="mt-4 w-full max-w-2xl mx-auto relative" @submit.prevent="handleSubmit">
+        <PromptInput class="mt-4 w-full max-w-2xl mx-auto relative" @submit.prevent="handleSubmit">
           <PromptInputTextarea
             v-model="input"
             placeholder="Say something..."
@@ -157,7 +163,7 @@ function handleSuggestionClick(suggestion: string) {
             :disabled="!input.trim()"
             class="absolute bottom-1 right-1"
           />
-        </Input>
+        </PromptInput>
       </div>
     </div>
   </div>

--- a/apps/www/content/3.components/5.utilities/code-block.md
+++ b/apps/www/content/3.components/5.utilities/code-block.md
@@ -279,7 +279,7 @@ import { useObject } from '@ai-sdk/vue'
 import { ref } from 'vue'
 import { z } from 'zod'
 import { CodeBlock, CodeBlockCopyButton } from '@/components/ai-elements/code-block'
-import { Input, PromptInputSubmit, PromptInputTextarea } from '@/components/ai-elements/prompt-input'
+import { PromptInput, PromptInputSubmit, PromptInputTextarea } from '@/components/ai-elements/prompt-input'
 
 const codeBlockSchema = z.object({
   language: z.string(),
@@ -315,7 +315,7 @@ function handleSubmit(e: Event) {
         </CodeBlock>
       </div>
 
-      <Input
+      <PromptInput
         class="mt-4 w-full max-w-2xl mx-auto relative"
         @submit="handleSubmit"
       >
@@ -329,7 +329,7 @@ function handleSubmit(e: Event) {
           :disabled="!input.trim()"
           class="absolute bottom-1 right-1"
         />
-      </Input>
+      </PromptInput>
     </div>
   </div>
 </template>

--- a/apps/www/content/3.components/5.utilities/loader.md
+++ b/apps/www/content/3.components/5.utilities/loader.md
@@ -115,7 +115,7 @@ import { ref } from 'vue'
 import { Conversation, ConversationContent, ConversationScrollButton } from '@/components/ai-elements/conversation'
 import { Loader } from '@/components/ai-elements/loader'
 import { Message, MessageContent } from '@/components/ai-elements/message'
-import { Input, PromptInputSubmit, PromptInputTextarea } from '@/components/ai-elements/prompt-input'
+import { PromptInput, PromptInputSubmit, PromptInputTextarea } from '@/components/ai-elements/prompt-input'
 
 const input = ref('')
 const { messages, sendMessage, status } = useChat()
@@ -149,7 +149,7 @@ function handleSubmit(e: Event) {
         <ConversationScrollButton />
       </Conversation>
 
-      <Input
+      <PromptInput
         class="mt-4 w-full max-w-2xl mx-auto relative"
         @submit.prevent="handleSubmit"
       >
@@ -163,7 +163,7 @@ function handleSubmit(e: Event) {
           :disabled="!input.trim()"
           class="absolute bottom-1 right-1"
         />
-      </Input>
+      </PromptInput>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Fix incorrect component usage across multiple documentation files where
the non-existent Input component was imported and used instead of PromptInput.
Also fix missing imports and incorrect function call in suggestion.md.

- loader.md: Replace Input import and usage with PromptInput
- code-block.md: Replace Input import and usage with PromptInput  
- sources.md: Replace Input import and usage with PromptInput
- suggestion.md: Fix setInput() call, add missing imports, replace Input with PromptInput