### PR TITLE
chore(docs): use `experimental_useObject` API in code-block example

### DIFF
--- a/apps/www/content/3.components/5.utilities/code-block.md
+++ b/apps/www/content/3.components/5.utilities/code-block.md
@@ -275,7 +275,7 @@ Add the following component to your frontend:
 ::::code-group
 ```vue [app/page.vue] height=500 collapse
 <script setup lang="ts">
-import { useObject } from '@ai-sdk/vue'
+import { experimental_useObject as useObject } from '@ai-sdk/vue'
 import { ref } from 'vue'
 import { z } from 'zod'
 import { CodeBlock, CodeBlockCopyButton } from '@/components/ai-elements/code-block'


### PR DESCRIPTION
Update code-block.md to use `experimental_useObject as useObject ` import to match the API naming convention used in other documentation files and align with the description that references `experimental_useObject`.