### PR TITLE
fix: update ComponentLoader to limit height of content area

### DIFF
--- a/apps/www/components/ComponentLoader.vue
+++ b/apps/www/components/ComponentLoader.vue
@@ -29,7 +29,7 @@ withDefaults(defineProps<Props>(), {
         >
           <ResizablePanelGroup direction="horizontal">
             <ResizablePanel :default-size="100">
-              <div class="h-[600px] overflow-auto">
+              <div class="max-h-[600px] overflow-auto">
                 <ComponentViewer :component-name="componentName" />
               </div>
             </ResizablePanel>


### PR DESCRIPTION
If the fixed height results in excessive white space in some documents, changing `height` to `max-height` can make it more aesthetically pleasing
### Old
<img width="827" height="885" alt="image" src="https://github.com/user-attachments/assets/b87d31c9-4c4c-49e2-a06c-792124735d94" />

### New
<img width="835" height="409" alt="image" src="https://github.com/user-attachments/assets/1fd5855d-cfb7-4644-9120-37774493218e" />
