### PR TITLE
chore(docs): add padding to ComponentLoader

### DIFF
--- a/apps/www/components/ComponentViewer.vue
+++ b/apps/www/components/ComponentViewer.vue
@@ -11,7 +11,7 @@ defineProps<Props>()
   <ClientOnly>
     <Suspense>
       <template #default>
-        <component :is="componentName" class="docs-component-preview p-1" />
+        <component :is="componentName" class="docs-component-preview" />
       </template>
       <template #fallback>
         <div class="p-4" />


### PR DESCRIPTION
Add `padding` to display the complete effect of the component
### Old
<img width="982" height="323" alt="c54d3aa17a5a51dc77b23edb9393876f" src="https://github.com/user-attachments/assets/ed52a0af-ec4b-4c21-a8f0-dc32877f7b7f" />
### New
<img width="643" height="360" alt="image" src="https://github.com/user-attachments/assets/d1d64766-57a6-420b-b75c-f76b2d6f330d" />
