### PR TITLE
refactor(confirmation): simplify approval type and tighten inject typing

### DIFF
--- a/apps/www/content/3.components/1.chatbot/confirmation.md
+++ b/apps/www/content/3.components/1.chatbot/confirmation.md
@@ -194,21 +194,6 @@ export type ToolUIPartApproval
     approved: boolean
     reason?: string
   }
-  | {
-    id: string
-    approved: true
-    reason?: string
-  }
-  | {
-    id: string
-    approved: true
-    reason?: string
-  }
-  | {
-    id: string
-    approved: false
-    reason?: string
-  }
   | undefined
 
 export interface ConfirmationContextValue {
@@ -220,7 +205,7 @@ export const ConfirmationKey: InjectionKey<ConfirmationContextValue>
   = Symbol('ConfirmationContext')
 
 export function useConfirmationContext() {
-  const context = inject<ConfirmationContextValue | null>(ConfirmationKey, null)
+  const context = inject(ConfirmationKey)
   if (!context)
     throw new Error('Confirmation components must be used within <Confirmation>')
   return context

--- a/packages/elements/src/confirmation/context.ts
+++ b/packages/elements/src/confirmation/context.ts
@@ -13,21 +13,6 @@ export type ToolUIPartApproval
     approved: boolean
     reason?: string
   }
-  | {
-    id: string
-    approved: true
-    reason?: string
-  }
-  | {
-    id: string
-    approved: true
-    reason?: string
-  }
-  | {
-    id: string
-    approved: false
-    reason?: string
-  }
   | undefined
 
 export interface ConfirmationContextValue {
@@ -39,7 +24,7 @@ export const ConfirmationKey: InjectionKey<ConfirmationContextValue>
   = Symbol('ConfirmationContext')
 
 export function useConfirmationContext() {
-  const context = inject<ConfirmationContextValue | null>(ConfirmationKey, null)
+  const context = inject(ConfirmationKey)
   if (!context)
     throw new Error('Confirmation components must be used within <Confirmation>')
   return context


### PR DESCRIPTION
Commit description
1. Simplify the ToolUIPartApproval union: keep a “pending” branch that forbids approved/reason, and a “responded” branch with approved: boolean and optional reason; remove redundant variants to improve readability and maintainability.
2. Use inject(ConfirmationKey) in useConfirmationContext to avoid manual generics/defaults, keeping runtime behavior the same while improving type accuracy.