### PR TITLE
fix(ComponentLoader): add padding styles to ComponentLoader

### DIFF
--- a/apps/www/components/ComponentLoader.vue
+++ b/apps/www/components/ComponentLoader.vue
@@ -29,7 +29,7 @@ withDefaults(defineProps<Props>(), {
         >
           <ResizablePanelGroup direction="horizontal">
             <ResizablePanel :default-size="100">
-              <div class="h-[600px] overflow-auto">
+              <div class="h-[600px] overflow-auto p-4">
                 <ComponentViewer :component-name="componentName" />
               </div>
             </ResizablePanel>


### PR DESCRIPTION
- sync padding of ai-element [preview.tsx](https://github.com/vercel/ai-elements/blob/main/apps/docs/components/custom/preview.tsx#L90) components when previewed, so that all components have padding when previewed
- Fixed the masked Prompt Input `has-[[data-slot=input-group-control]:focus-visible]` class