### PR TITLE
fix(prompt-input): stopPropagation on drop

### DIFF
--- a/packages/elements/src/prompt-input/PromptInput.vue
+++ b/packages/elements/src/prompt-input/PromptInput.vue
@@ -103,7 +103,7 @@ function onSubmit(e: Event) {
       :class="cn('w-full', props.class)"
       @submit="onSubmit"
       @dragover.prevent="handleDragOver"
-      @drop.prevent="handleDrop"
+      @drop.prevent.stop="handleDrop"
     >
       <InputGroup class="overflow-hidden">
         <slot />


### PR DESCRIPTION
Problem Description:
When `globalDrop` is set to `true`, the `handleDrop` handler is triggered twice, resulting in duplicated execution.

Solution:
Add local `@drag` event listeners with the `.stop` modifier to prevent event propagation, ensuring that `handleDrop` is triggered only once.