### PR TITLE
fix(code-block): show scrollbar for long lines

### DIFF
--- a/packages/elements/src/code-block/CodeBlock.vue
+++ b/packages/elements/src/code-block/CodeBlock.vue
@@ -69,11 +69,11 @@ onBeforeUnmount(() => {
   >
     <div class="relative">
       <div
-        class="overflow-x-scroll dark:hidden [&>pre]:m-0 [&>pre]:bg-background! [&>pre]:p-4 [&>pre]:text-foreground! [&>pre]:text-sm [&_code]:font-mono [&_code]:text-sm"
+        class="overflow-auto dark:hidden [&>pre]:m-0 [&>pre]:bg-background! [&>pre]:p-4 [&>pre]:text-foreground! [&>pre]:text-sm [&_code]:font-mono [&_code]:text-sm"
         v-html="html"
       />
       <div
-        class="hidden overflow-x-scroll dark:block [&>pre]:m-0 [&>pre]:bg-background! [&>pre]:p-4 [&>pre]:text-foreground! [&>pre]:text-sm [&_code]:font-mono [&_code]:text-sm"
+        class="hidden overflow-auto dark:block [&>pre]:m-0 [&>pre]:bg-background! [&>pre]:p-4 [&>pre]:text-foreground! [&>pre]:text-sm [&_code]:font-mono [&_code]:text-sm"
         v-html="darkHtml"
       />
       <div v-if="$slots.default" class="absolute top-2 right-2 flex items-center gap-2">


### PR DESCRIPTION
See the issue: [#114](https://github.com/vuepont/ai-elements-vue/issues/114)

**Before**
<img width="1512" height="948" alt="before" src="https://github.com/user-attachments/assets/0b004160-3848-40bf-85fb-08f1adaaf3a3" />
**Fixed**
<img width="1512" height="948" alt="after" src="https://github.com/user-attachments/assets/ee1a80de-0408-4b04-b713-d27fb96020bc" />
