### PR TITLE
chore: remove explicit NuxtApp typing in ai-elements plugin

### DIFF
--- a/apps/www/plugins/ai-elements.ts
+++ b/apps/www/plugins/ai-elements.ts
@@ -1,10 +1,9 @@
-import type { NuxtApp } from 'nuxt/app'
 import * as Components from '@repo/examples'
 import ComponentLoader from '@/components/ComponentLoader.vue'
 import ComponentViewer from '@/components/ComponentViewer.vue'
 import ElementsDemo from '@/components/ElementsDemo.vue'
 
-export default defineNuxtPlugin((nuxtApp: NuxtApp) => {
+export default defineNuxtPlugin((nuxtApp) => {
   const { vueApp } = nuxtApp
 
   vueApp.component('ComponentLoader', ComponentLoader)


### PR DESCRIPTION
Remove explicit NuxtApp type annotation and rely on defineNuxtPlugin type inference to avoid plugin signature type mismatch.

<img width="1039" height="276" alt="PixPin_2026-01-27_15-38-46" src="https://github.com/user-attachments/assets/329a3623-cab6-4c23-a049-5fa4e2297401" />
