### PR TITLE
feat(cli): support custom registry via `ELEMENTS_REGISTRY_URL`

### DIFF
--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -3,6 +3,9 @@
 const { spawnSync } = require('node:child_process')
 const process = require('node:process')
 
+const ELEMENTS_REGISTRY_URL
+  = process.env.ELEMENTS_REGISTRY_URL ?? 'https://registry.ai-elements-vue.com'
+
 // Function to detect the command used to invoke this script
 function getCommandPrefix() {
   // Check for common package manager environment variables
@@ -39,7 +42,7 @@ const targetUrls = components
   .map(component =>
     new URL(
       `${component}.json`,
-      'https://registry.ai-elements-vue.com/',
+      ELEMENTS_REGISTRY_URL,
     ).toString(),
   )
   .join(' ')


### PR DESCRIPTION
Summary: Replaced hardcoded registry URL with a configurable ELEMENTS_REGISTRY_URL environment variable.

Why: To enable support for private or staging registries, allowing users to switch sources without modifying source code.