### PR TITLE
fix(model-selector): scroll to selected model when reopening selector

### DIFF
--- a/packages/elements/src/model-selector/ModelSelectorContent.vue
+++ b/packages/elements/src/model-selector/ModelSelectorContent.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { AcceptableValue } from 'reka-ui'
 import type { HTMLAttributes } from 'vue'
 import { Command } from '@repo/shadcn-vue/components/ui/command'
 import { DialogContent, DialogTitle } from '@repo/shadcn-vue/components/ui/dialog'
@@ -12,6 +13,7 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
   title: 'Model Selector',
 })
+const value = defineModel<AcceptableValue | AcceptableValue[]>()
 </script>
 
 <template>
@@ -22,7 +24,7 @@ const props = withDefaults(defineProps<Props>(), {
     <DialogTitle class="sr-only">
       {{ props.title }}
     </DialogTitle>
-    <Command class="**:data-[slot=command-input-wrapper]:h-auto">
+    <Command v-model="value" class="**:data-[slot=command-input-wrapper]:h-auto">
       <slot />
     </Command>
   </DialogContent>


### PR DESCRIPTION
<img width="612" height="422" alt="企业微信截图_1780762242854" src="https://github.com/user-attachments/assets/e6e55bd6-f7ee-46c5-a464-f08195bbe2fc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved model selector component's data binding with enhanced type safety for more reliable two-way value synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->